### PR TITLE
Warning if no dat

### DIFF
--- a/phycontrib/template/gui.py
+++ b/phycontrib/template/gui.py
@@ -196,9 +196,10 @@ class TemplateController(Controller):
                                     )
             n_samples_t, _ = traces.shape
             assert _ == self.n_channels_dat
-        elif self.dat_path is not None:
-            logger.warning("Error while loading data: File %s not found.",
-                           self.dat_path)
+        else:
+            if self.dat_path is not None:
+                logger.warning("Error while loading data: File %s not found.",
+                               self.dat_path)
             traces = None
             n_samples_t = 0
 

--- a/phycontrib/template/gui.py
+++ b/phycontrib/template/gui.py
@@ -197,6 +197,8 @@ class TemplateController(Controller):
             n_samples_t, _ = traces.shape
             assert _ == self.n_channels_dat
         else:
+            logger.warning("Error while loading dat: File %s does not exists.",
+                           self.dat_path)
             traces = None
             n_samples_t = 0
 

--- a/phycontrib/template/gui.py
+++ b/phycontrib/template/gui.py
@@ -196,8 +196,8 @@ class TemplateController(Controller):
                                     )
             n_samples_t, _ = traces.shape
             assert _ == self.n_channels_dat
-        else:
-            logger.warning("Error while loading dat: File %s does not exists.",
+        elif self.dat_path is not None:
+            logger.warning("Error while loading data: File %s not found.",
                            self.dat_path)
             traces = None
             n_samples_t = 0


### PR DESCRIPTION
If the dat file given to phy template is invalid, template-gui silently ignores it and doesn't load the view that need data. It took me a while to understand why the waveform view had disappeared, so I've added a small warning to tell that it cannot load the dat file.